### PR TITLE
Support for disabling email reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ The container is configurable through the following environment variables:
 	Set to `yes` to trigger a sync when the container starts, in addition to the
 	normal cron schedule.
 
+* **`GMVAULT_EMAIL_REPORT`** *(optional)*
+	Set to `no` to not send email reports.
+
 
 Thanks
 ------

--- a/backup_full.sh
+++ b/backup_full.sh
@@ -3,8 +3,13 @@
 echo "Starting full sync of $GMVAULT_EMAIL_ADDRESS."
 echo "Report will be sent to $GMVAULT_SEND_REPORTS_TO."
 
-gmvault sync -d /data $GMVAULT_OPTIONS $GMVAULT_EMAIL_ADDRESS 2>&1 \
-	| tee /data/${GMVAULT_EMAIL_ADDRESS}_full.log \
-	| mail -s "Mail Backup (full) | $GMVAULT_EMAIL_ADDRESS | `date +'%Y-%m-%d %r %Z'`" $GMVAULT_SEND_REPORTS_TO
+LOGFILE="/data/${GMVAULT_EMAIL_ADDRESS}_full.log"
+
+gmvault sync -d /data $GMVAULT_OPTIONS $GMVAULT_EMAIL_ADDRESS 2>&1 > $LOGFILE
+
+if [ "$GMVAULT_EMAIL_REPORT" != "no" ]
+then
+    cat $LOGFILE | mail -s "Mail Backup (full) | $GMVAULT_EMAIL_ADDRESS | `date +'%Y-%m-%d %r %Z'`" $GMVAULT_SEND_REPORTS_TO
+fi
 
 echo "Full sync complete."

--- a/backup_quick.sh
+++ b/backup_quick.sh
@@ -3,8 +3,13 @@
 echo "Starting quick sync of $GMVAULT_EMAIL_ADDRESS."
 echo "Report will be sent to $GMVAULT_SEND_REPORTS_TO."
 
-gmvault sync -t quick -d /data $GMVAULT_OPTIONS $GMVAULT_EMAIL_ADDRESS 2>&1 \
-	| tee /data/${GMVAULT_EMAIL_ADDRESS}_quick.log \
-	| mail -s "Mail Backup (quick) | $GMVAULT_EMAIL_ADDRESS | `date +'%Y-%m-%d %r %Z'`" $GMVAULT_SEND_REPORTS_TO
+LOGFILE="/data/${GMVAULT_EMAIL_ADDRESS}_quick.log"
+
+gmvault sync -t quick -d /data $GMVAULT_OPTIONS $GMVAULT_EMAIL_ADDRESS 2>&1 > $LOGFILE
+
+if [ "$GMVAULT_EMAIL_REPORT" != "no" ]
+then
+    cat $LOGFILE | mail -s "Mail Backup (quick) | $GMVAULT_EMAIL_ADDRESS | `date +'%Y-%m-%d %r %Z'`" $GMVAULT_SEND_REPORTS_TO
+fi
 
 echo "Quick sync complete."


### PR DESCRIPTION
Adds the possibility of disabling email reports by setting a specific environment variable, `GMVAULT_EMAIL_REPORT`, to `no`.

Current behaviour is maintained if the variable is not defined or is set to any other value.