### PR TITLE
.oauth2 file subject to $GMVAULT_DIR variable

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OAUTH_TOKEN="/data/${GMVAULT_EMAIL_ADDRESS}.oauth2"
+OAUTH_TOKEN="$GMVAULT_DIR/${GMVAULT_EMAIL_ADDRESS}.oauth2"
 
 if [ "$GMVAULT_OPTIONS" != "" ]; then
 	echo "Gmvault will run with the following additional options: $GMVAULT_OPTIONS."


### PR DESCRIPTION
default $GMVAULT_DIR set to "/data"
allows configuration to be separated from true data.